### PR TITLE
Fix linter warnings of staticcheck

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -377,7 +377,7 @@ func (b *Bucket) MultiPut(pairs ...[]byte) error {
 				for _, ref := range c.stack[:len(c.stack)-1] {
 					_assert(!n.isLeaf, "expected branch node")
 					n.inodes[ref.index].size++
-					n = n.childAt(int(ref.index))
+					n = n.childAt(ref.index)
 				}
 			}
 		}
@@ -463,7 +463,7 @@ func (b *Bucket) Delete(key []byte) error {
 		for _, ref := range c.stack[:len(c.stack)-1] {
 			_assert(!n.isLeaf, "expected branch node")
 			n.inodes[ref.index].size--
-			n = n.childAt(int(ref.index))
+			n = n.childAt(ref.index)
 		}
 	}
 

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -111,8 +111,8 @@ func TestBucket_Get_Capacity(t *testing.T) {
 		}
 
 		// Ensure slice can be appended to without a segfault.
-		k = append(k, []byte("123")...)
-		v = append(v, []byte("123")...)
+		_ = append(k, []byte("123")...)
+		_ = append(v, []byte("123")...)
 
 		return nil
 	}); err != nil {

--- a/tx.go
+++ b/tx.go
@@ -348,7 +348,7 @@ func (tx *Tx) WriteTo(w io.Writer) (n int64, err error) {
 	}
 
 	// Move past the meta pages in the file.
-	if _, err := f.Seek(int64(tx.db.pageSize*2), os.SEEK_SET); err != nil {
+	if _, err := f.Seek(int64(tx.db.pageSize*2), io.SeekStart); err != nil {
 		return n, fmt.Errorf("seek: %s", err)
 	}
 


### PR DESCRIPTION
Fix results of `golangci-lint run --disable-all --enable=staticcheck .`

```
bucket_test.go:114:3: SA4006: this value of `k` is never used (staticcheck)
		k = append(k, []byte("123")...)
		^
bucket_test.go:115:3: SA4006: this value of `v` is never used (staticcheck)
		v = append(v, []byte("123")...)
		^
db_test.go:359:2: SA4006: this value of `db` is never used (staticcheck)
	db, err = bolt.Open(path, 0666, nil)
	^
tx.go:351:47: SA1019: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (staticcheck)
	if _, err := f.Seek(int64(tx.db.pageSize*2), os.SEEK_SET); err != nil {
	                                             ^
bucket_test.go:1188:3: SA9003: empty branch (staticcheck)
		if stats.BranchInuse != branchInuse {
		^
bucket_test.go:1196:3: SA9003: empty branch (staticcheck)
		if stats.LeafInuse != leafInuse {
		^
db_test.go:407:2: SA2002: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (staticcheck)
	go func() {
	^
db_test.go:480:2: SA2002: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (staticcheck)
	go func() {
	^
db_test.go:1299:4: SA2002: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (staticcheck)
			go func(id uint32) {
			^
```

And one warning I didn't fix, because not sure: 
```
tx.go:553:21: SA6002: argument should be pointer-like to avoid allocations (staticcheck)
		tx.db.pagePool.Put(buf)
		                  ^
```