### PR TITLE
Test never ending because can't close DB before all Tx's rolled back

### DIFF
--- a/tx_test.go
+++ b/tx_test.go
@@ -62,6 +62,8 @@ func TestTx_Commit_ErrTxNotWritable(t *testing.T) {
 	if err := tx.Commit(); err != bolt.ErrTxNotWritable {
 		t.Fatal(err)
 	}
+	// Close the view transaction
+	tx.Rollback()
 }
 
 // Ensure that a transaction can retrieve a cursor on the root bucket.


### PR DESCRIPTION
TestTx_Commit_ErrTxNotWritable never ending because not possible to close db if any TX was not rolled back

Actually I found interesting side effect:
- `db.go:Close()` method was waiting for `mmaplock.Lock()` - it means: It was not possible to Close db if any ongoing tx are exist. 
- But now we have yieldTx() method which releasing `mmaplock` - it means: now possible to close DB if ongoing tx performed yieldTx() exists. 

Need look closer - what happening when you close db with opened yielded transactions - maybe it can corrupt data or something else.