### PR TITLE
revive cmd bench

### DIFF
--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -1044,7 +1044,7 @@ func (cmd *BenchCommand) runWritesWithSource(db *bolt.DB, options *BenchOptions,
 
 	for i := 0; i < options.Iterations; i += options.BatchSize {
 		if err := db.Update(func(tx *bolt.Tx) error {
-			b, _ := tx.CreateBucketIfNotExists(benchBucketName)
+			b, _ := tx.CreateBucketIfNotExists(benchBucketName, false)
 			b.FillPercent = options.FillPercent
 
 			for j := 0; j < options.BatchSize; j++ {
@@ -1073,7 +1073,7 @@ func (cmd *BenchCommand) runWritesNestedWithSource(db *bolt.DB, options *BenchOp
 
 	for i := 0; i < options.Iterations; i += options.BatchSize {
 		if err := db.Update(func(tx *bolt.Tx) error {
-			top, err := tx.CreateBucketIfNotExists(benchBucketName)
+			top, err := tx.CreateBucketIfNotExists(benchBucketName, false)
 			if err != nil {
 				return err
 			}
@@ -1084,7 +1084,7 @@ func (cmd *BenchCommand) runWritesNestedWithSource(db *bolt.DB, options *BenchOp
 			binary.BigEndian.PutUint32(name, keySource())
 
 			// Create bucket.
-			b, err := top.CreateBucketIfNotExists(name)
+			b, err := top.CreateBucketIfNotExists(name, false)
 			if err != nil {
 				return err
 			}
@@ -1646,7 +1646,7 @@ func (cmd *CompactCommand) compact(dst, src *bolt.DB) error {
 		// Create bucket on the root transaction if this is the first level.
 		nk := len(keys)
 		if nk == 0 {
-			bkt, err := tx.CreateBucket(k)
+			bkt, err := tx.CreateBucket(k, false)
 			if err != nil {
 				return err
 			}
@@ -1666,7 +1666,7 @@ func (cmd *CompactCommand) compact(dst, src *bolt.DB) error {
 
 		// If there is no value then this is a bucket call.
 		if v == nil {
-			bkt, err := b.CreateBucket(k)
+			bkt, err := b.CreateBucket(k, false)
 			if err != nil {
 				return err
 			}

--- a/cmd/bolt/main_test.go
+++ b/cmd/bolt/main_test.go
@@ -81,7 +81,7 @@ func TestStatsCommand_Run(t *testing.T) {
 
 	if err := db.Update(func(tx *bolt.Tx) error {
 		// Create "foo" bucket.
-		b, err := tx.CreateBucket([]byte("foo"))
+		b, err := tx.CreateBucket([]byte("foo"), true)
 		if err != nil {
 			return err
 		}
@@ -92,7 +92,7 @@ func TestStatsCommand_Run(t *testing.T) {
 		}
 
 		// Create "bar" bucket.
-		b, err = tx.CreateBucket([]byte("bar"))
+		b, err = tx.CreateBucket([]byte("bar"), true)
 		if err != nil {
 			return err
 		}
@@ -103,7 +103,7 @@ func TestStatsCommand_Run(t *testing.T) {
 		}
 
 		// Create "baz" bucket.
-		b, err = tx.CreateBucket([]byte("baz"))
+		b, err = tx.CreateBucket([]byte("baz"), true)
 		if err != nil {
 			return err
 		}
@@ -205,7 +205,7 @@ func TestCompactCommand_Run(t *testing.T) {
 		n := 2 + rand.Intn(5)
 		for i := 0; i < n; i++ {
 			k := []byte(fmt.Sprintf("b%d", i))
-			b, err := tx.CreateBucketIfNotExists(k)
+			b, err := tx.CreateBucketIfNotExists(k, true)
 			if err != nil {
 				return err
 			}
@@ -224,7 +224,7 @@ func TestCompactCommand_Run(t *testing.T) {
 
 	// make the db grow by adding large values, and delete them.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucketIfNotExists([]byte("large_vals"))
+		b, err := tx.CreateBucketIfNotExists([]byte("large_vals"), true)
 		if err != nil {
 			return err
 		}
@@ -309,7 +309,7 @@ func fillBucket(b *bolt.Bucket, prefix []byte) error {
 	n = 1 + rand.Intn(3)
 	for i := 0; i < n; i++ {
 		k := append(prefix, []byte(fmt.Sprintf("b%d", i))...)
-		sb, err := b.CreateBucket(k)
+		sb, err := b.CreateBucket(k, true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
There is built-in bench command in bolt: `go run ./cmd/bolt bench -h` 
Revived it. And here are results:

Default: 
```
# Write	26.41058ms	(26.41µs/op)	(37864 op/sec)
# Read	1.000111889s	(96ns/op)	(10416666 op/sec)
```

KeyPrefixCompressionDisabled: true
```
# Write	24.743642ms	(24.743µs/op)	(40415 op/sec)
# Read	1.000011812s	(56ns/op)	(17857142 op/sec)
```

MemOnly: true
```
# Write	1.097315ms	(1.097µs/op)	(911577 op/sec)
# Read	1.000055998s	(85ns/op)	(11764705 op/sec)
```
