### PR TITLE
[WIP] Reduce amount of allocations in PrefixCompression feature

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -95,9 +95,10 @@ func (b *Bucket) Cursor() *Cursor {
 
 	// Allocate and return a cursor.
 	return &Cursor{
-		bucket: b,
-		stack:  make([]elemRef, 0),
-		keyBuf: make([]byte, 32),
+		bucket:            b,
+		stack:             make([]elemRef, 0),
+		keyBuf:            make([]byte, 32),
+		prefixCompression: !b.tx.db.KeysPrefixCompressionDisable,
 	}
 }
 
@@ -756,9 +757,10 @@ func (b *Bucket) inlineable() bool {
 	// our threshold for inline bucket size.
 	var size = pageHeaderSize
 	var prefix []byte
+	var prefixCompression = !b.tx.db.KeysPrefixCompressionDisable
 	for i, inode := range n.inodes {
 		size += leafPageElementSize + uintptr(len(inode.key)) + uintptr(len(inode.value))
-		if !b.tx.db.KeysPrefixCompressionDisable {
+		if prefixCompression {
 			if prefix == nil {
 				prefix = inode.key
 			} else {

--- a/bucket.go
+++ b/bucket.go
@@ -97,6 +97,7 @@ func (b *Bucket) Cursor() *Cursor {
 	return &Cursor{
 		bucket: b,
 		stack:  make([]elemRef, 0),
+		keyBuf: make([]byte, 32),
 	}
 }
 

--- a/bucket.go
+++ b/bucket.go
@@ -92,7 +92,6 @@ func (b *Bucket) Writable() bool {
 func (b *Bucket) Cursor() *Cursor {
 	// Update transaction statistics.
 	b.tx.stats.CursorCount++
-
 	// Allocate and return a cursor.
 	return &Cursor{
 		bucket:            b,

--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -1107,8 +1107,8 @@ func (cmd *BucketsCommand) Run(args ...string) error {
 
 	// Print buckets.
 	return db.View(func(tx *bolt.Tx) error {
-		return tx.ForEach(func(name []byte, _ *bolt.Bucket) error {
-			fmt.Fprintln(cmd.Stdout, string(name))
+		return tx.ForEach(func(name []byte, b *bolt.Bucket) error {
+			fmt.Fprintln(cmd.Stdout, string(name), fmt.Sprintf("%.1fM", float64(b.Stats().KeyN)/1_000_000))
 			return nil
 		})
 	})

--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -1618,7 +1618,6 @@ func (cmd *BenchCommand) runReadsSeekTo(db *bolt.DB, options *BenchOptions, resu
 func (cmd *BenchCommand) runReadsSequential(db *bolt.DB, options *BenchOptions, results *BenchResults) error {
 	return db.View(func(tx *bolt.Tx) error {
 		t := time.Now()
-
 		for {
 			var count int
 

--- a/cmd/bolt/main_test.go
+++ b/cmd/bolt/main_test.go
@@ -164,7 +164,7 @@ func TestBucketsCommand_Run(t *testing.T) {
 	}
 	db.DB.Close()
 
-	expected := "bar\nbaz\nfoo\n"
+	expected := "bar 0.0M\nbaz 0.0M\nfoo 0.0M\n"
 
 	// Run the command.
 	m := NewMain()

--- a/cursor.go
+++ b/cursor.go
@@ -18,7 +18,6 @@ import (
 type Cursor struct {
 	bucket *Bucket
 	stack  []elemRef
-	keyBuf []byte
 	idx    uint64
 }
 
@@ -235,7 +234,7 @@ func (c *Cursor) seekTo(seek []byte) (key []byte, value []byte, flags uint32) {
 					} else {
 						lastkey = lastkey[:0]
 						lastkey = append(lastkey, p.keyPrefix()...)
-						lastkey = append(lastkey, p.leafPageElement(p.count-1).key()...)
+						lastkey = append(lastkey, p.branchPageElementX(p.count-1).key()...)
 					}
 				} else {
 					if c.bucket.tx.db.KeysPrefixCompressionDisable {
@@ -243,7 +242,7 @@ func (c *Cursor) seekTo(seek []byte) (key []byte, value []byte, flags uint32) {
 					} else {
 						lastkey = lastkey[:0]
 						lastkey = append(lastkey, p.keyPrefix()...)
-						lastkey = append(lastkey, p.leafPageElement(p.count-1).key()...)
+						lastkey = append(lastkey, p.branchPageElement(p.count-1).key()...)
 					}
 				}
 			}
@@ -592,11 +591,7 @@ func (c *Cursor) keyValue() ([]byte, []byte, uint32) {
 	p := c.bucket.lookupPage(ref.pageID)
 	elem := p.leafPageElement(uint16(ref.index))
 	if !c.bucket.tx.db.KeysPrefixCompressionDisable {
-		c.keyBuf = c.keyBuf[:0]
-		c.keyBuf = append(c.keyBuf, p.keyPrefix()...)
-		c.keyBuf = append(c.keyBuf, elem.key()...)
-		l := int(p.prefixsize) + len(elem.key())
-		return c.keyBuf[:l:l], elem.value(), elem.flags
+		return append(p.keyPrefix(), elem.key()...), elem.value(), elem.flags
 	}
 	return elem.key(), elem.value(), elem.flags
 }

--- a/node.go
+++ b/node.go
@@ -219,7 +219,9 @@ func (n *node) read(p *page) {
 			if n.bucket.tx.db.KeysPrefixCompressionDisable {
 				inode.key = elem.key()
 			} else {
-				inode.key = append(prefix, elem.key()...)
+				inode.key = inode.key[:0]
+				inode.key = append(inode.key, prefix...)
+				inode.key = append(inode.key, elem.key()...)
 			}
 			inode.value = elem.value()
 		} else {
@@ -229,7 +231,9 @@ func (n *node) read(p *page) {
 				if n.bucket.tx.db.KeysPrefixCompressionDisable {
 					inode.key = elem.key()
 				} else {
-					inode.key = append(prefix, elem.key()...)
+					inode.key = inode.key[:0]
+					inode.key = append(inode.key, prefix...)
+					inode.key = append(inode.key, elem.key()...)
 				}
 				inode.size = minSize + uint64(elem.size)
 			} else {
@@ -238,7 +242,9 @@ func (n *node) read(p *page) {
 				if n.bucket.tx.db.KeysPrefixCompressionDisable {
 					inode.key = elem.key()
 				} else {
-					inode.key = append(prefix, elem.key()...)
+					inode.key = inode.key[:0]
+					inode.key = append(inode.key, prefix...)
+					inode.key = append(inode.key, elem.key()...)
 				}
 			}
 		}

--- a/node.go
+++ b/node.go
@@ -224,9 +224,7 @@ func (n *node) read(p *page) {
 			elem := p.leafPageElement(uint16(i))
 			inode.flags = elem.flags
 			if prefixCompression {
-				inode.key = inode.key[:0]
-				inode.key = append(inode.key, prefix...)
-				inode.key = append(inode.key, elem.key()...)
+				inode.key = append(prefix, elem.key()...)
 			} else {
 				inode.key = elem.key()
 			}
@@ -236,9 +234,7 @@ func (n *node) read(p *page) {
 				elem := p.branchPageElementX(uint16(i))
 				inode.pgid = elem.pgid
 				if prefixCompression {
-					inode.key = inode.key[:0]
-					inode.key = append(inode.key, prefix...)
-					inode.key = append(inode.key, elem.key()...)
+					inode.key = append(prefix, elem.key()...)
 				} else {
 					inode.key = elem.key()
 				}
@@ -247,9 +243,7 @@ func (n *node) read(p *page) {
 				elem := p.branchPageElement(uint16(i))
 				inode.pgid = elem.pgid
 				if prefixCompression {
-					inode.key = inode.key[:0]
-					inode.key = append(inode.key, prefix...)
-					inode.key = append(inode.key, elem.key()...)
+					inode.key = append(prefix, elem.key()...)
 				} else {
 					inode.key = elem.key()
 				}


### PR DESCRIPTION
Results:
Reads bench results: 92ns/op -> 70ns/op

To compare:
Disabled PrefixCompression: 62ns/op

Cons: 
Key now valid not during transaction but until cursor.Next() call (badger gives the same guaranties - until cursor.Next() call) - I think it's not very dangerous. 

Run turbo-geth tests on this version: https://github.com/ledgerwatch/turbo-geth/pull/380