### PR TITLE
Fix unsafe pointer conversions caught by Go 1.14 checkptr

### DIFF
--- a/bolt_386.go
+++ b/bolt_386.go
@@ -5,6 +5,3 @@ const maxMapSize = 0x7FFFFFFF // 2GB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0xFFFFFFF
-
-// Are unaligned load/stores broken on this arch?
-var brokenUnaligned = false

--- a/bolt_amd64.go
+++ b/bolt_amd64.go
@@ -5,6 +5,3 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
-
-// Are unaligned load/stores broken on this arch?
-var brokenUnaligned = false

--- a/bolt_arm.go
+++ b/bolt_arm.go
@@ -1,28 +1,7 @@
 package bolt
 
-import "unsafe"
-
 // maxMapSize represents the largest mmap size supported by Bolt.
 const maxMapSize = 0x7FFFFFFF // 2GB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0xFFFFFFF
-
-// Are unaligned load/stores broken on this arch?
-var brokenUnaligned bool
-
-func init() {
-	// Simple check to see whether this arch handles unaligned load/stores
-	// correctly.
-
-	// ARM9 and older devices require load/stores to be from/to aligned
-	// addresses. If not, the lower 2 bits are cleared and that address is
-	// read in a jumbled up order.
-
-	// See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka15414.html
-
-	raw := [6]byte{0xfe, 0xef, 0x11, 0x22, 0x22, 0x11}
-	val := *(*uint32)(unsafe.Pointer(uintptr(unsafe.Pointer(&raw)) + 2))
-
-	brokenUnaligned = val != 0x11222211
-}

--- a/bolt_arm64.go
+++ b/bolt_arm64.go
@@ -7,6 +7,3 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
-
-// Are unaligned load/stores broken on this arch?
-var brokenUnaligned = false

--- a/bolt_ppc64.go
+++ b/bolt_ppc64.go
@@ -7,6 +7,3 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
-
-// Are unaligned load/stores broken on this arch?
-var brokenUnaligned = false

--- a/bolt_ppc64le.go
+++ b/bolt_ppc64le.go
@@ -7,6 +7,3 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
-
-// Are unaligned load/stores broken on this arch?
-var brokenUnaligned = false

--- a/bolt_s390x.go
+++ b/bolt_s390x.go
@@ -7,6 +7,3 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
-
-// Are unaligned load/stores broken on this arch?
-var brokenUnaligned = false

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -429,12 +429,12 @@ func TestBucket_Delete_NonExisting(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if _, err = b.CreateBucket([]byte("nested"), false); err != nil {
+		if _, err = b.CreateBucket([]byte("nested")); err != nil {
 			t.Fatal(err)
 		}
 		return nil

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -1937,4 +1937,5 @@ func ExampleBucket_ForEach() {
 	// A cat is lame.
 	// A dog is fun.
 	// A liger is awesome.
+
 }

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -22,7 +22,7 @@ func TestBucket_Get_NonExistent(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -41,7 +41,7 @@ func TestBucket_Get_FromNode(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -62,12 +62,12 @@ func TestBucket_Get_IncompatibleValue(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucket([]byte("widgets"), false)
+		_, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if _, err := tx.Bucket([]byte("widgets")).CreateBucket([]byte("foo"), false); err != nil {
+		if _, err := tx.Bucket([]byte("widgets")).CreateBucket([]byte("foo")); err != nil {
 			t.Fatal(err)
 		}
 		v, _ := tx.Bucket([]byte("widgets")).Get([]byte("foo"))
@@ -90,7 +90,7 @@ func TestBucket_Get_Capacity(t *testing.T) {
 
 	// Write key to a bucket.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("bucket"), false)
+		b, err := tx.CreateBucket([]byte("bucket"))
 		if err != nil {
 			return err
 		}
@@ -125,7 +125,7 @@ func TestBucket_Put(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -148,7 +148,7 @@ func TestBucket_Put_Repeat(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -176,7 +176,7 @@ func TestBucket_Put_Large(t *testing.T) {
 
 	count, factor := 100, 200
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -218,7 +218,7 @@ func TestDB_Put_VeryLarge(t *testing.T) {
 
 	for i := 0; i < n; i += batchN {
 		if err := db.Update(func(tx *bolt.Tx) error {
-			b, err := tx.CreateBucketIfNotExists([]byte("widgets"), false)
+			b, err := tx.CreateBucketIfNotExists([]byte("widgets"))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -242,12 +242,12 @@ func TestBucket_Put_IncompatibleValue(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b0, err := tx.CreateBucket([]byte("widgets"), false)
+		b0, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if _, err := tx.Bucket([]byte("widgets")).CreateBucket([]byte("foo"), false); err != nil {
+		if _, err := tx.Bucket([]byte("widgets")).CreateBucket([]byte("foo")); err != nil {
 			t.Fatal(err)
 		}
 		if err := b0.Put([]byte("foo"), []byte("bar")); err != bolt.ErrIncompatibleValue {
@@ -268,7 +268,7 @@ func TestBucket_Put_Closed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b, err := tx.CreateBucket([]byte("widgets"), false)
+	b, err := tx.CreateBucket([]byte("widgets"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +288,7 @@ func TestBucket_Put_ReadOnly(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -313,7 +313,7 @@ func TestBucket_Delete(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -338,7 +338,7 @@ func TestBucket_Delete_Large(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -389,7 +389,7 @@ func TestBucket_Delete_FreelistOverflow(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucketIfNotExists([]byte("0"), false)
+		b, err := tx.CreateBucketIfNotExists([]byte("0"))
 		if err != nil {
 			t.Fatalf("bucket error: %s", err)
 		}
@@ -463,13 +463,13 @@ func TestBucket_Nested(t *testing.T) {
 
 	if err := db.Update(func(tx *bolt.Tx) error {
 		// Create a widgets bucket.
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// Create a widgets/foo bucket.
-		_, err = b.CreateBucket([]byte("foo"), false)
+		_, err = b.CreateBucket([]byte("foo"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -548,11 +548,11 @@ func TestBucket_Delete_Bucket(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := b.CreateBucket([]byte("foo"), false); err != nil {
+		if _, err := b.CreateBucket([]byte("foo")); err != nil {
 			t.Fatal(err)
 		}
 		if err := b.Delete([]byte("foo")); err != bolt.ErrIncompatibleValue {
@@ -570,7 +570,7 @@ func TestBucket_Delete_ReadOnly(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -598,7 +598,7 @@ func TestBucket_Delete_Closed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b, err := tx.CreateBucket([]byte("widgets"), false)
+	b, err := tx.CreateBucket([]byte("widgets"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -617,17 +617,17 @@ func TestBucket_DeleteBucket_Nested(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		widgets, err := tx.CreateBucket([]byte("widgets"), false)
+		widgets, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		foo, err := widgets.CreateBucket([]byte("foo"), false)
+		foo, err := widgets.CreateBucket([]byte("foo"))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		bar, err := foo.CreateBucket([]byte("bar"), false)
+		bar, err := foo.CreateBucket([]byte("bar"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -649,17 +649,17 @@ func TestBucket_DeleteBucket_Nested2(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		widgets, err := tx.CreateBucket([]byte("widgets"), false)
+		widgets, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		foo, err := widgets.CreateBucket([]byte("foo"), false)
+		foo, err := widgets.CreateBucket([]byte("foo"))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		bar, err := foo.CreateBucket([]byte("bar"), false)
+		bar, err := foo.CreateBucket([]byte("bar"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -716,12 +716,12 @@ func TestBucket_DeleteBucket_Large(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		widgets, err := tx.CreateBucket([]byte("widgets"), false)
+		widgets, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		foo, err := widgets.CreateBucket([]byte("foo"), false)
+		foo, err := widgets.CreateBucket([]byte("foo"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -752,7 +752,7 @@ func TestBucket_Bucket_IncompatibleValue(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		widgets, err := tx.CreateBucket([]byte("widgets"), false)
+		widgets, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -774,7 +774,7 @@ func TestBucket_CreateBucket_IncompatibleValue(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		widgets, err := tx.CreateBucket([]byte("widgets"), false)
+		widgets, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -782,7 +782,7 @@ func TestBucket_CreateBucket_IncompatibleValue(t *testing.T) {
 		if err := widgets.Put([]byte("foo"), []byte("bar")); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := widgets.CreateBucket([]byte("foo"), false); err != bolt.ErrIncompatibleValue {
+		if _, err := widgets.CreateBucket([]byte("foo")); err != bolt.ErrIncompatibleValue {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		return nil
@@ -797,7 +797,7 @@ func TestBucket_DeleteBucket_IncompatibleValue(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		widgets, err := tx.CreateBucket([]byte("widgets"), false)
+		widgets, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -819,7 +819,7 @@ func TestBucket_Sequence(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		bkt, err := tx.CreateBucket([]byte("0"), false)
+		bkt, err := tx.CreateBucket([]byte("0"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -861,11 +861,11 @@ func TestBucket_NextSequence(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		widgets, err := tx.CreateBucket([]byte("widgets"), false)
+		widgets, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
-		woojits, err := tx.CreateBucket([]byte("woojits"), false)
+		woojits, err := tx.CreateBucket([]byte("woojits"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -904,7 +904,7 @@ func TestBucket_NextSequence_Persist(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -940,7 +940,7 @@ func TestBucket_NextSequence_ReadOnly(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -967,7 +967,7 @@ func TestBucket_NextSequence_Closed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := tx.CreateBucket([]byte("widgets"), false)
+	b, err := tx.CreateBucket([]byte("widgets"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -985,7 +985,7 @@ func TestBucket_ForEach(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1042,7 +1042,7 @@ func TestBucket_ForEach_ShortCircuit(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1086,7 +1086,7 @@ func TestBucket_ForEach_Closed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b, err := tx.CreateBucket([]byte("widgets"), false)
+	b, err := tx.CreateBucket([]byte("widgets"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1106,7 +1106,7 @@ func TestBucket_Put_EmptyKey(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1127,7 +1127,7 @@ func TestBucket_Put_KeyTooLarge(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1151,7 +1151,7 @@ func TestBucket_Put_ValueTooLarge(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1173,7 +1173,7 @@ func _TestBucket_Stats(t *testing.T) {
 	bigKey := []byte("really-big-value")
 	for i := 0; i < 500; i++ {
 		if err := db.Update(func(tx *bolt.Tx) error {
-			b, err := tx.CreateBucketIfNotExists([]byte("woojits"), false)
+			b, err := tx.CreateBucketIfNotExists([]byte("woojits"))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1268,7 +1268,7 @@ func _TestBucket_Stats_RandomFill(t *testing.T) {
 	rand := rand.New(rand.NewSource(42))
 	for _, i := range rand.Perm(1000) {
 		if err := db.Update(func(tx *bolt.Tx) error {
-			b, err := tx.CreateBucketIfNotExists([]byte("woojits"), false)
+			b, err := tx.CreateBucketIfNotExists([]byte("woojits"))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1326,7 +1326,7 @@ func _TestBucket_Stats_Small(t *testing.T) {
 
 	if err := db.Update(func(tx *bolt.Tx) error {
 		// Add a bucket that fits on a single root leaf.
-		b, err := tx.CreateBucket([]byte("whozawhats"), false)
+		b, err := tx.CreateBucket([]byte("whozawhats"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1390,7 +1390,7 @@ func _TestBucket_Stats_EmptyBucket(t *testing.T) {
 
 	if err := db.Update(func(tx *bolt.Tx) error {
 		// Add a bucket that fits on a single root leaf.
-		if _, err := tx.CreateBucket([]byte("whozawhats"), false); err != nil {
+		if _, err := tx.CreateBucket([]byte("whozawhats")); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -1449,7 +1449,7 @@ func _TestBucket_Stats_Nested(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("foo"), false)
+		b, err := tx.CreateBucket([]byte("foo"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1459,7 +1459,7 @@ func _TestBucket_Stats_Nested(t *testing.T) {
 			}
 		}
 
-		bar, err := b.CreateBucket([]byte("bar"), false)
+		bar, err := b.CreateBucket([]byte("bar"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1469,7 +1469,7 @@ func _TestBucket_Stats_Nested(t *testing.T) {
 			}
 		}
 
-		baz, err := bar.CreateBucket([]byte("baz"), false)
+		baz, err := bar.CreateBucket([]byte("baz"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1558,7 +1558,7 @@ func _TestBucket_Stats_Large(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		// Add bucket with lots of keys.
 		if err := db.Update(func(tx *bolt.Tx) error {
-			b, err := tx.CreateBucketIfNotExists([]byte("widgets"), false)
+			b, err := tx.CreateBucketIfNotExists([]byte("widgets"))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1632,7 +1632,7 @@ func TestBucket_Put_Single(t *testing.T) {
 		m := make(map[string][]byte)
 
 		if err := db.Update(func(tx *bolt.Tx) error {
-			if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+			if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 				t.Fatal(err)
 			}
 			return nil
@@ -1688,7 +1688,7 @@ func TestBucket_Put_Multiple(t *testing.T) {
 
 		// Bulk insert all values.
 		if err := db.Update(func(tx *bolt.Tx) error {
-			if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+			if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 				t.Fatal(err)
 			}
 			return nil
@@ -1741,7 +1741,7 @@ func TestBucket_Delete_Quick(t *testing.T) {
 
 		// Bulk insert all values.
 		if err := db.Update(func(tx *bolt.Tx) error {
-			if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+			if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 				t.Fatal(err)
 			}
 			return nil
@@ -1800,7 +1800,7 @@ func ExampleBucket_Put() {
 	// Start a write transaction.
 	if err := db.Update(func(tx *bolt.Tx) error {
 		// Create a bucket.
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			return err
 		}
@@ -1843,7 +1843,7 @@ func ExampleBucket_Delete() {
 	// Start a write transaction.
 	if err := db.Update(func(tx *bolt.Tx) error {
 		// Create a bucket.
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			return err
 		}
@@ -1900,7 +1900,7 @@ func ExampleBucket_ForEach() {
 
 	// Insert data into a bucket.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("animals"), false)
+		b, err := tx.CreateBucket([]byte("animals"))
 		if err != nil {
 			return err
 		}

--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -1426,7 +1426,7 @@ func (cmd *BenchCommand) runWritesWithSource(db *bolt.DB, options *BenchOptions,
 
 	for i := 0; i < options.Iterations; i += options.BatchSize {
 		if err := db.Update(func(tx *bolt.Tx) error {
-			b, _ := tx.CreateBucketIfNotExists(benchBucketName, false)
+			b, _ := tx.CreateBucketIfNotExists(benchBucketName)
 			b.FillPercent = options.FillPercent
 
 			for j := 0; j < options.BatchSize; j++ {
@@ -1455,7 +1455,7 @@ func (cmd *BenchCommand) runWritesNestedWithSource(db *bolt.DB, options *BenchOp
 
 	for i := 0; i < options.Iterations; i += options.BatchSize {
 		if err := db.Update(func(tx *bolt.Tx) error {
-			top, err := tx.CreateBucketIfNotExists(benchBucketName, false)
+			top, err := tx.CreateBucketIfNotExists(benchBucketName)
 			if err != nil {
 				return err
 			}
@@ -1466,7 +1466,7 @@ func (cmd *BenchCommand) runWritesNestedWithSource(db *bolt.DB, options *BenchOp
 			binary.BigEndian.PutUint32(name, keySource())
 
 			// Create bucket.
-			b, err := top.CreateBucketIfNotExists(name, false)
+			b, err := top.CreateBucketIfNotExists(name)
 			if err != nil {
 				return err
 			}
@@ -2030,7 +2030,7 @@ func (cmd *CompactCommand) compact(dst, src *bolt.DB) error {
 		// Create bucket on the root transaction if this is the first level.
 		nk := len(keys)
 		if nk == 0 {
-			bkt, err := tx.CreateBucket(k, false)
+			bkt, err := tx.CreateBucket(k)
 			if err != nil {
 				return err
 			}
@@ -2050,7 +2050,7 @@ func (cmd *CompactCommand) compact(dst, src *bolt.DB) error {
 
 		// If there is no value then this is a bucket call.
 		if v == nil {
-			bkt, err := b.CreateBucket(k, false)
+			bkt, err := b.CreateBucket(k)
 			if err != nil {
 				return err
 			}

--- a/cmd/bolt/main_test.go
+++ b/cmd/bolt/main_test.go
@@ -81,7 +81,7 @@ func _TestStatsCommand_Run(t *testing.T) {
 
 	if err := db.Update(func(tx *bolt.Tx) error {
 		// Create "foo" bucket.
-		b, err := tx.CreateBucket([]byte("foo"), false)
+		b, err := tx.CreateBucket([]byte("foo"))
 		if err != nil {
 			return err
 		}
@@ -92,7 +92,7 @@ func _TestStatsCommand_Run(t *testing.T) {
 		}
 
 		// Create "bar" bucket.
-		b, err = tx.CreateBucket([]byte("bar"), false)
+		b, err = tx.CreateBucket([]byte("bar"))
 		if err != nil {
 			return err
 		}
@@ -103,7 +103,7 @@ func _TestStatsCommand_Run(t *testing.T) {
 		}
 
 		// Create "baz" bucket.
-		b, err = tx.CreateBucket([]byte("baz"), false)
+		b, err = tx.CreateBucket([]byte("baz"))
 		if err != nil {
 			return err
 		}
@@ -153,7 +153,7 @@ func TestBucketsCommand_Run(t *testing.T) {
 
 	if err := db.Update(func(tx *bolt.Tx) error {
 		for _, name := range []string{"foo", "bar", "baz"} {
-			_, err := tx.CreateBucket([]byte(name), false)
+			_, err := tx.CreateBucket([]byte(name))
 			if err != nil {
 				return err
 			}
@@ -182,7 +182,7 @@ func TestKeysCommand_Run(t *testing.T) {
 
 	if err := db.Update(func(tx *bolt.Tx) error {
 		for _, name := range []string{"foo", "bar"} {
-			b, err := tx.CreateBucket([]byte(name), false)
+			b, err := tx.CreateBucket([]byte(name))
 			if err != nil {
 				return err
 			}
@@ -217,7 +217,7 @@ func TestGetCommand_Run(t *testing.T) {
 
 	if err := db.Update(func(tx *bolt.Tx) error {
 		for _, name := range []string{"foo", "bar"} {
-			b, err := tx.CreateBucket([]byte(name), false)
+			b, err := tx.CreateBucket([]byte(name))
 			if err != nil {
 				return err
 			}
@@ -305,7 +305,7 @@ func TestCompactCommand_Run(t *testing.T) {
 		n := 2 + rand.Intn(5)
 		for i := 0; i < n; i++ {
 			k := []byte(fmt.Sprintf("b%d", i))
-			b, err := tx.CreateBucketIfNotExists(k, false)
+			b, err := tx.CreateBucketIfNotExists(k)
 			if err != nil {
 				return err
 			}
@@ -324,7 +324,7 @@ func TestCompactCommand_Run(t *testing.T) {
 
 	// make the db grow by adding large values, and delete them.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucketIfNotExists([]byte("large_vals"), false)
+		b, err := tx.CreateBucketIfNotExists([]byte("large_vals"))
 		if err != nil {
 			return err
 		}
@@ -409,7 +409,7 @@ func fillBucket(b *bolt.Bucket, prefix []byte) error {
 	n = 1 + rand.Intn(3)
 	for i := 0; i < n; i++ {
 		k := append(prefix, []byte(fmt.Sprintf("b%d", i))...)
-		sb, err := b.CreateBucket(k, false)
+		sb, err := b.CreateBucket(k)
 		if err != nil {
 			return err
 		}

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -19,7 +19,7 @@ func TestCursor_Bucket(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -37,7 +37,7 @@ func TestCursor_Seek(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -51,7 +51,7 @@ func TestCursor_Seek(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if _, err := b.CreateBucket([]byte("bkt"), false); err != nil {
+		if _, err := b.CreateBucket([]byte("bkt")); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -111,7 +111,7 @@ func TestCursor_Delete(t *testing.T) {
 
 	// Insert every other key between 0 and $count.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -122,7 +122,7 @@ func TestCursor_Delete(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		if _, err := b.CreateBucket([]byte("sub"), false); err != nil {
+		if _, err := b.CreateBucket([]byte("sub")); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -174,7 +174,7 @@ func TestCursor_Seek_Large(t *testing.T) {
 
 	// Insert every other key between 0 and $count.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -234,7 +234,7 @@ func TestCursor_EmptyBucket(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucket([]byte("widgets"), false)
+		_, err := tx.CreateBucket([]byte("widgets"))
 		return err
 	}); err != nil {
 		t.Fatal(err)
@@ -260,7 +260,7 @@ func TestCursor_EmptyBucketReverse(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucket([]byte("widgets"), false)
+		_, err := tx.CreateBucket([]byte("widgets"))
 		return err
 	}); err != nil {
 		t.Fatal(err)
@@ -285,7 +285,7 @@ func TestCursor_Iterate_Leaf(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -356,7 +356,7 @@ func TestCursor_LeafRootReverse(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -420,7 +420,7 @@ func TestCursor_Restart(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -467,7 +467,7 @@ func TestCursor_First_EmptyPages(t *testing.T) {
 
 	// Create 1000 keys in the "widgets" bucket.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -518,7 +518,7 @@ func TestCursor_QuickCheck(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -576,7 +576,7 @@ func TestCursor_QuickCheck_Reverse(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -628,17 +628,17 @@ func TestCursor_QuickCheck_BucketsOnly(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := b.CreateBucket([]byte("foo"), false); err != nil {
+		if _, err := b.CreateBucket([]byte("foo")); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := b.CreateBucket([]byte("bar"), false); err != nil {
+		if _, err := b.CreateBucket([]byte("bar")); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := b.CreateBucket([]byte("baz"), false); err != nil {
+		if _, err := b.CreateBucket([]byte("baz")); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -670,17 +670,17 @@ func TestCursor_QuickCheck_BucketsOnly_Reverse(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := b.CreateBucket([]byte("foo"), false); err != nil {
+		if _, err := b.CreateBucket([]byte("foo")); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := b.CreateBucket([]byte("bar"), false); err != nil {
+		if _, err := b.CreateBucket([]byte("bar")); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := b.CreateBucket([]byte("baz"), false); err != nil {
+		if _, err := b.CreateBucket([]byte("baz")); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -717,7 +717,7 @@ func ExampleCursor() {
 	// Start a read-write transaction.
 	if err := db.Update(func(tx *bolt.Tx) error {
 		// Create a new bucket.
-		b, err := tx.CreateBucket([]byte("animals"), false)
+		b, err := tx.CreateBucket([]byte("animals"))
 		if err != nil {
 			return err
 		}
@@ -771,7 +771,7 @@ func ExampleCursor_reverse() {
 	// Start a read-write transaction.
 	if err := db.Update(func(tx *bolt.Tx) error {
 		// Create a new bucket.
-		b, err := tx.CreateBucket([]byte("animals"), false)
+		b, err := tx.CreateBucket([]byte("animals"))
 		if err != nil {
 			return err
 		}

--- a/db_test.go
+++ b/db_test.go
@@ -1241,7 +1241,7 @@ func ExampleDB_View() {
 	// John's last name is doe.
 }
 
-func ExampleDB_Begin_ReadOnly() {
+func ExampleDB_Begin() {
 	// Open the database.
 	db, err := bolt.Open(tempfile(), 0666, nil)
 	if err != nil {

--- a/db_test.go
+++ b/db_test.go
@@ -232,7 +232,7 @@ func TestOpen_Size(t *testing.T) {
 
 	// Insert until we get above the minimum 4MB size.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, _ := tx.CreateBucketIfNotExists([]byte("data"), false)
+		b, _ := tx.CreateBucketIfNotExists([]byte("data"))
 		for i := 0; i < 10000; i++ {
 			if err := b.Put([]byte(fmt.Sprintf("%04d", i)), make([]byte, 1000)); err != nil {
 				t.Fatal(err)
@@ -299,7 +299,7 @@ func TestOpen_Size_Large(t *testing.T) {
 	var v = make([]byte, 1_000_000)
 	for i := 0; i < 100; i++ {
 		if err := db.Batch(func(tx *bolt.Tx) error {
-			b, _ := tx.CreateBucketIfNotExists([]byte("data"), false)
+			b, _ := tx.CreateBucketIfNotExists([]byte("data"))
 			for j := 0; j < 100; j++ {
 				if err := b.Put(u64tob(index), v); err != nil {
 					t.Fatal(err)
@@ -433,7 +433,7 @@ func TestDB_Open_InitialMmapSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b, err := wtx.CreateBucket([]byte("test"), false)
+	b, err := wtx.CreateBucket([]byte("test"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -476,7 +476,7 @@ func TestDB_Open_ReadOnly(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -621,7 +621,7 @@ func TestDB_Update(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -656,7 +656,7 @@ func TestDB_Update(t *testing.T) {
 func TestDB_Update_Closed(t *testing.T) {
 	var db bolt.DB
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -783,7 +783,7 @@ func TestDB_Update_Panic(t *testing.T) {
 		}()
 
 		if err := db.Update(func(tx *bolt.Tx) error {
-			if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+			if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 				t.Fatal(err)
 			}
 			panic("omg")
@@ -794,7 +794,7 @@ func TestDB_Update_Panic(t *testing.T) {
 
 	// Verify we can update again.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -831,7 +831,7 @@ func TestDB_View_Panic(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -873,7 +873,7 @@ func TestDB_Stats(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucket([]byte("widgets"), false)
+		_, err := tx.CreateBucket([]byte("widgets"))
 		return err
 	}); err != nil {
 		t.Fatal(err)
@@ -894,7 +894,7 @@ func TestDB_Consistency(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucket([]byte("widgets"), false)
+		_, err := tx.CreateBucket([]byte("widgets"))
 		return err
 	}); err != nil {
 		t.Fatal(err)
@@ -981,7 +981,7 @@ func TestDB_Batch(t *testing.T) {
 	defer db.MustClose()
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -1056,7 +1056,7 @@ func TestDB_BatchFull(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucket([]byte("widgets"), false)
+		_, err := tx.CreateBucket([]byte("widgets"))
 		return err
 	}); err != nil {
 		t.Fatal(err)
@@ -1115,7 +1115,7 @@ func TestDB_BatchTime(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucket([]byte("widgets"), false)
+		_, err := tx.CreateBucket([]byte("widgets"))
 		return err
 	}); err != nil {
 		t.Fatal(err)
@@ -1168,7 +1168,7 @@ func ExampleDB_Update() {
 
 	// Execute several commands within a read-write transaction.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			return err
 		}
@@ -1208,7 +1208,7 @@ func ExampleDB_View() {
 
 	// Insert data into a bucket.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("people"), false)
+		b, err := tx.CreateBucket([]byte("people"))
 		if err != nil {
 			return err
 		}
@@ -1251,7 +1251,7 @@ func ExampleDB_Begin_ReadOnly() {
 
 	// Create a bucket using a read-write transaction.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucket([]byte("widgets"), false)
+		_, err := tx.CreateBucket([]byte("widgets"))
 		return err
 	}); err != nil {
 		log.Fatal(err)
@@ -1304,7 +1304,7 @@ func BenchmarkDBBatchAutomatic(b *testing.B) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucket([]byte("bench"), false)
+		_, err := tx.CreateBucket([]byte("bench"))
 		return err
 	}); err != nil {
 		b.Fatal(err)
@@ -1349,7 +1349,7 @@ func BenchmarkDBBatchSingle(b *testing.B) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucket([]byte("bench"), false)
+		_, err := tx.CreateBucket([]byte("bench"))
 		return err
 	}); err != nil {
 		b.Fatal(err)
@@ -1393,7 +1393,7 @@ func BenchmarkDBBatchManual10x100(b *testing.B) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucket([]byte("bench"), false)
+		_, err := tx.CreateBucket([]byte("bench"))
 		return err
 	}); err != nil {
 		b.Fatal(err)

--- a/freelist_test.go
+++ b/freelist_test.go
@@ -95,7 +95,7 @@ func TestFreelist_read(t *testing.T) {
 	page.count = 2
 
 	// Insert 2 page ids.
-	ids := (*[3]pgid)(unsafe.Pointer(&page.ptr))
+	ids := (*[3]pgid)(unsafe.Pointer(uintptr(unsafe.Pointer(page)) + pageHeaderSize))
 	ids[0] = 23
 	ids[1] = 50
 

--- a/go.mod
+++ b/go.mod
@@ -3,4 +3,3 @@ module github.com/ledgerwatch/bolt
 go 1.13
 
 require golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
-

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,4 @@ module github.com/ledgerwatch/bolt
 go 1.13
 
 require golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
+

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200331124033-c3d80250170d h1:nc5K6ox/4lTFbMVSL9WRR81ixkcwXThoiF6yf+R9scA=
-golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/node.go
+++ b/node.go
@@ -39,7 +39,7 @@ func (n *node) minKeys() int {
 
 // size returns the size of the node after serialization.
 func (n *node) size() int {
-	sz, elsz := int(pageHeaderSize), int(n.pageElementSize())
+	sz, elsz := pageHeaderSize, n.pageElementSize()
 	var prefix []byte
 	for i := 0; i < len(n.inodes); i++ {
 		item := &n.inodes[i]
@@ -57,10 +57,10 @@ func (n *node) size() int {
 				prefix = prefix[:j]
 			}
 		}
-		sz += elsz + len(item.key) + len(item.value)
+		sz += elsz + uintptr(len(item.key)) + uintptr(len(item.value))
 	}
-	sz -= len(prefix) * (len(n.inodes) - 1) // Prefix is only included once4
-	return sz
+	sz -= uintptr(len(prefix)) * (uintptr(len(n.inodes)) - 1) // Prefix is only included once
+	return int(sz)
 }
 
 // sizeLessThan returns true if the node is less than a given size.

--- a/node.go
+++ b/node.go
@@ -254,9 +254,8 @@ func (n *node) write(p *page) {
 	if p.count == 0 {
 		return
 	}
-	// Calculate common prefix and minSize
+	// Calculate common prefix
 	var prefix []byte
-	var minSize uint64 = 0
 	for _, item := range n.inodes {
 		if !n.bucket.tx.db.KeysPrefixCompressionDisable {
 			if prefix == nil {
@@ -280,7 +279,6 @@ func (n *node) write(p *page) {
 		_assert(plen == 0, "key prefix: non-zero prefix in db with disabled keys compression")
 	}
 
-	p.minsize = minSize
 	bp := uintptr(unsafe.Pointer(p)) + pageHeaderSize + n.pageElementSize()*uintptr(len(n.inodes))
 	b := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
 		Data: bp,

--- a/node_test.go
+++ b/node_test.go
@@ -39,7 +39,7 @@ func TestNode_read_LeafPage(t *testing.T) {
 	page.count = 2
 
 	// Insert 2 elements at the beginning. sizeof(leafPageElement) == 16
-	nodes := (*[3]leafPageElement)(unsafe.Pointer(&page.ptr))
+	nodes := (*[3]leafPageElement)(unsafe.Pointer(uintptr(unsafe.Pointer(page)) + pageHeaderSize))
 	nodes[0] = leafPageElement{flags: 0, pos: 32, ksize: 3, vsize: 4}  // pos = sizeof(leafPageElement) * 2
 	nodes[1] = leafPageElement{flags: 0, pos: 23, ksize: 10, vsize: 3} // pos = sizeof(leafPageElement) + 3 + 4
 

--- a/page.go
+++ b/page.go
@@ -12,7 +12,6 @@ const pageHeaderSize = int(unsafe.Offsetof(((*page)(nil)).ptr))
 const minKeysPerPage = 2
 
 const branchPageElementSize = int(unsafe.Sizeof(branchPageElement{}))
-const branchPageElementSizeX = int(unsafe.Sizeof(branchPageElementX{}))
 const leafPageElementSize = int(unsafe.Sizeof(leafPageElement{}))
 
 const (
@@ -77,25 +76,12 @@ func (p *page) branchPageElement(index uint16) *branchPageElement {
 	return &((*[0x7FFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[index]
 }
 
-// branchPageElementX retrieves the extended branch node by index
-func (p *page) branchPageElementX(index uint16) *branchPageElementX {
-	return &((*[0x7FFFFFF]branchPageElementX)(unsafe.Pointer(&p.ptr)))[index]
-}
-
 // branchPageElements retrieves a list of branch nodes.
 func (p *page) branchPageElements() []branchPageElement {
 	if p.count == 0 {
 		return nil
 	}
 	return ((*[0x7FFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[:]
-}
-
-// branchPageElements retrieves a list of branch nodes.
-func (p *page) branchPageElementsX() []branchPageElementX {
-	if p.count == 0 {
-		return nil
-	}
-	return ((*[0x7FFFFFF]branchPageElementX)(unsafe.Pointer(&p.ptr)))[:]
 }
 
 func (p *page) keyPrefix() []byte {
@@ -122,22 +108,8 @@ type branchPageElement struct {
 	pgid  pgid
 }
 
-// branchPageElement represents a node on a branch page.
-type branchPageElementX struct {
-	pos   uint32
-	ksize uint32
-	pgid  pgid
-	size  uint32
-}
-
 // key returns a byte slice of the node key.
 func (n *branchPageElement) key() []byte {
-	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
-	return (*[maxAllocSize]byte)(unsafe.Pointer(&buf[n.pos]))[:n.ksize]
-}
-
-// key returns a byte slice of the node key.
-func (n *branchPageElementX) key() []byte {
 	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
 	return (*[maxAllocSize]byte)(unsafe.Pointer(&buf[n.pos]))[:n.ksize]
 }

--- a/page.go
+++ b/page.go
@@ -36,7 +36,6 @@ type page struct {
 	prefixpos  uint32
 	prefixsize uint32
 	ptr        uintptr
-	minsize    uint64
 }
 
 // typ returns a human readable page type string used for debugging.

--- a/page.go
+++ b/page.go
@@ -3,16 +3,19 @@ package bolt
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"sort"
 	"unsafe"
 )
 
-const pageHeaderSize = int(unsafe.Offsetof(((*page)(nil)).ptr))
+const pageHeaderSize = unsafe.Offsetof(((*page)(nil)).ptr)
+
+//const pageHeaderSize = unsafe.Sizeof(page{})
 
 const minKeysPerPage = 2
 
-const branchPageElementSize = int(unsafe.Sizeof(branchPageElement{}))
-const leafPageElementSize = int(unsafe.Sizeof(leafPageElement{}))
+const branchPageElementSize = unsafe.Sizeof(branchPageElement{})
+const leafPageElementSize = unsafe.Sizeof(leafPageElement{})
 
 const (
 	branchPageFlag   = 0x01
@@ -54,13 +57,16 @@ func (p *page) typ() string {
 
 // meta returns a pointer to the metadata section of the page.
 func (p *page) meta() *meta {
-	return (*meta)(unsafe.Pointer(&p.ptr))
+	//return (*meta)(unsafe.Pointer(&p.ptr))
+	return (*meta)(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + unsafe.Sizeof(*p)))
 }
 
 // leafPageElement retrieves the leaf node by index
 func (p *page) leafPageElement(index uint16) *leafPageElement {
-	n := &((*[0x7FFFFFF]leafPageElement)(unsafe.Pointer(&p.ptr)))[index]
+	n := &((*[maxAllocSize]leafPageElement)(unsafe.Pointer(&p.ptr)))[index]
 	return n
+	off := uintptr(index) * unsafe.Sizeof(leafPageElement{})
+	return (*leafPageElement)(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + unsafe.Sizeof(*p) + off))
 }
 
 // leafPageElements retrieves a list of leaf nodes.
@@ -69,11 +75,18 @@ func (p *page) leafPageElements() []leafPageElement {
 		return nil
 	}
 	return ((*[0x7FFFFFF]leafPageElement)(unsafe.Pointer(&p.ptr)))[:]
+	return *(*[]leafPageElement)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(p)) + unsafe.Sizeof(*p),
+		Len:  int(p.count),
+		Cap:  int(p.count),
+	}))
 }
 
 // branchPageElement retrieves the branch node by index
 func (p *page) branchPageElement(index uint16) *branchPageElement {
 	return &((*[0x7FFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[index]
+	off := uintptr(index) * unsafe.Sizeof(branchPageElement{})
+	return (*branchPageElement)(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + unsafe.Sizeof(*p) + off))
 }
 
 // branchPageElements retrieves a list of branch nodes.
@@ -82,6 +95,11 @@ func (p *page) branchPageElements() []branchPageElement {
 		return nil
 	}
 	return ((*[0x7FFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[:]
+	return *(*[]branchPageElement)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(p)) + unsafe.Sizeof(*p),
+		Len:  int(p.count),
+		Cap:  int(p.count),
+	}))
 }
 
 func (p *page) keyPrefix() []byte {
@@ -91,7 +109,11 @@ func (p *page) keyPrefix() []byte {
 
 // dump writes n bytes of the page to STDERR as hex output.
 func (p *page) hexdump(n int) {
-	buf := (*[maxAllocSize]byte)(unsafe.Pointer(p))[:n]
+	buf := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(p)),
+		Len:  n,
+		Cap:  n,
+	}))
 	fmt.Fprintf(os.Stderr, "%x\n", buf)
 }
 
@@ -110,8 +132,11 @@ type branchPageElement struct {
 
 // key returns a byte slice of the node key.
 func (n *branchPageElement) key() []byte {
-	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
-	return (*[maxAllocSize]byte)(unsafe.Pointer(&buf[n.pos]))[:n.ksize]
+	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(n)) + uintptr(n.pos),
+		Len:  int(n.ksize),
+		Cap:  int(n.ksize),
+	}))
 }
 
 // leafPageElement represents a node on a leaf page.
@@ -124,14 +149,20 @@ type leafPageElement struct {
 
 // key returns a byte slice of the node key.
 func (n *leafPageElement) key() []byte {
-	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
-	return (*[maxAllocSize]byte)(unsafe.Pointer(&buf[n.pos]))[:n.ksize:n.ksize]
+	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(n)) + uintptr(n.pos),
+		Len:  int(n.ksize),
+		Cap:  int(n.ksize),
+	}))
 }
 
 // value returns a byte slice of the node value.
 func (n *leafPageElement) value() []byte {
-	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
-	return (*[maxAllocSize]byte)(unsafe.Pointer(&buf[n.pos+n.ksize]))[:n.vsize:n.vsize]
+	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(n)) + uintptr(n.pos) + uintptr(n.ksize),
+		Len:  int(n.vsize),
+		Cap:  int(n.vsize),
+	}))
 }
 
 // PageInfo represents human readable information about a page.

--- a/page.go
+++ b/page.go
@@ -8,7 +8,8 @@ import (
 	"unsafe"
 )
 
-const pageHeaderSize = unsafe.Offsetof(((*page)(nil)).ptr)
+//const pageHeaderSize = unsafe.Offsetof(((*page)(nil)).ptr)
+const pageHeaderSize = unsafe.Sizeof(page{})
 
 const minKeysPerPage = 2
 
@@ -35,7 +36,6 @@ type page struct {
 	overflow   uint32
 	prefixpos  uint32
 	prefixsize uint32
-	ptr        uintptr
 }
 
 // typ returns a human readable page type string used for debugging.

--- a/simulation_test.go
+++ b/simulation_test.go
@@ -174,7 +174,7 @@ func simulatePutHandler(tx *bolt.Tx, qdb *QuickDB) {
 	// Retrieve root bucket.
 	b := tx.Bucket(keys[0])
 	if b == nil {
-		b, err = tx.CreateBucket(keys[0], false)
+		b, err = tx.CreateBucket(keys[0])
 		if err != nil {
 			panic("create bucket: " + err.Error())
 		}
@@ -186,7 +186,7 @@ func simulatePutHandler(tx *bolt.Tx, qdb *QuickDB) {
 		if child != nil {
 			b = child
 		} else {
-			b, err = b.CreateBucket(key, false)
+			b, err = b.CreateBucket(key)
 			if err != nil {
 				panic("create bucket: " + err.Error())
 			}

--- a/tx.go
+++ b/tx.go
@@ -104,15 +104,15 @@ func (tx *Tx) Bucket(name []byte) *Bucket {
 // CreateBucket creates a new bucket.
 // Returns an error if the bucket already exists, if the bucket name is blank, or if the bucket name is too long.
 // The bucket instance is only valid for the lifetime of the transaction.
-func (tx *Tx) CreateBucket(name []byte, enum bool) (*Bucket, error) {
-	return tx.root.CreateBucket(name, enum)
+func (tx *Tx) CreateBucket(name []byte) (*Bucket, error) {
+	return tx.root.CreateBucket(name)
 }
 
 // CreateBucketIfNotExists creates a new bucket if it doesn't already exist.
 // Returns an error if the bucket name is blank, or if the bucket name is too long.
 // The bucket instance is only valid for the lifetime of the transaction.
-func (tx *Tx) CreateBucketIfNotExists(name []byte, enum bool) (*Bucket, error) {
-	return tx.root.CreateBucketIfNotExists(name, enum)
+func (tx *Tx) CreateBucketIfNotExists(name []byte) (*Bucket, error) {
+	return tx.root.CreateBucketIfNotExists(name)
 }
 
 // DeleteBucket deletes a bucket.

--- a/tx.go
+++ b/tx.go
@@ -478,7 +478,7 @@ func (tx *Tx) allocate(count int) (*page, error) {
 	tx.pages[p.id] = p
 
 	// Update statistics.
-	tx.stats.PageCount++
+	tx.stats.PageCount += count
 	tx.stats.PageAlloc += count * tx.db.pageSize
 
 	return p, nil
@@ -520,7 +520,7 @@ func (tx *Tx) write() error {
 			}
 
 			// Update statistics.
-			tx.stats.Write += sz
+			tx.stats.Write++
 
 			// Exit inner for loop if we've written all the chunks.
 			size -= sz

--- a/tx.go
+++ b/tx.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -500,7 +501,7 @@ func (tx *Tx) write() error {
 		offset := int64(p.id) * int64(tx.db.pageSize)
 
 		// Write out page in "max allocation" sized chunks.
-		ptr := (*[maxAllocSize]byte)(unsafe.Pointer(p))
+		ptr := uintptr(unsafe.Pointer(p))
 		for {
 			// Limit our write to our max allocation size.
 			sz := size
@@ -509,7 +510,11 @@ func (tx *Tx) write() error {
 			}
 
 			// Write chunk to disk.
-			buf := ptr[:sz]
+			buf := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+				Data: ptr,
+				Len:  sz,
+				Cap:  sz,
+			}))
 			if _, err := tx.db.ops.writeAt(buf, offset); err != nil {
 				return err
 			}
@@ -525,7 +530,7 @@ func (tx *Tx) write() error {
 
 			// Otherwise move offset forward and move pointer to next chunk.
 			offset += int64(sz)
-			ptr = (*[maxAllocSize]byte)(unsafe.Pointer(&ptr[sz]))
+			ptr += uintptr(sz)
 		}
 	}
 
@@ -544,7 +549,11 @@ func (tx *Tx) write() error {
 			continue
 		}
 
-		buf := (*[maxAllocSize]byte)(unsafe.Pointer(p))[:tx.db.pageSize]
+		buf := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+			Data: uintptr(unsafe.Pointer(p)),
+			Len:  tx.db.pageSize,
+			Cap:  tx.db.pageSize,
+		}))
 
 		// See https://go.googlesource.com/go/+/f03c9202c43e0abb130669852082117ca50aa9b1
 		for i := range buf {

--- a/tx_test.go
+++ b/tx_test.go
@@ -16,7 +16,7 @@ func TestTx_Check_ReadOnly(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -70,7 +70,7 @@ func TestTx_Commit_ErrTxClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := tx.CreateBucket([]byte("foo"), false); err != nil {
+	if _, err := tx.CreateBucket([]byte("foo")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -121,11 +121,11 @@ func TestTx_Cursor(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 			t.Fatal(err)
 		}
 
-		if _, err := tx.CreateBucket([]byte("woojits"), false); err != nil {
+		if _, err := tx.CreateBucket([]byte("woojits")); err != nil {
 			t.Fatal(err)
 		}
 
@@ -159,7 +159,7 @@ func TestTx_CreateBucket_ErrTxNotWritable(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.View(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucket([]byte("foo"), false)
+		_, err := tx.CreateBucket([]byte("foo"))
 		if err != bolt.ErrTxNotWritable {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -181,7 +181,7 @@ func TestTx_CreateBucket_ErrTxClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := tx.CreateBucket([]byte("foo"), false); err != bolt.ErrTxClosed {
+	if _, err := tx.CreateBucket([]byte("foo")); err != bolt.ErrTxClosed {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -191,7 +191,7 @@ func TestTx_Bucket(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 			t.Fatal(err)
 		}
 		if tx.Bucket([]byte("widgets")) == nil {
@@ -208,7 +208,7 @@ func TestTx_Get_NotFound(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -233,7 +233,7 @@ func TestTx_CreateBucket(t *testing.T) {
 
 	// Create a bucket.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		} else if b == nil {
@@ -261,14 +261,14 @@ func TestTx_CreateBucketIfNotExists(t *testing.T) {
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
 		// Create bucket.
-		if b, err := tx.CreateBucketIfNotExists([]byte("widgets"), false); err != nil {
+		if b, err := tx.CreateBucketIfNotExists([]byte("widgets")); err != nil {
 			t.Fatal(err)
 		} else if b == nil {
 			t.Fatal("expected bucket")
 		}
 
 		// Create bucket again.
-		if b, err := tx.CreateBucketIfNotExists([]byte("widgets"), false); err != nil {
+		if b, err := tx.CreateBucketIfNotExists([]byte("widgets")); err != nil {
 			t.Fatal(err)
 		} else if b == nil {
 			t.Fatal("expected bucket")
@@ -295,11 +295,11 @@ func TestTx_CreateBucketIfNotExists_ErrBucketNameRequired(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if _, err := tx.CreateBucketIfNotExists([]byte{}, false); err != bolt.ErrBucketNameRequired {
+		if _, err := tx.CreateBucketIfNotExists([]byte{}); err != bolt.ErrBucketNameRequired {
 			t.Fatalf("unexpected error: %s", err)
 		}
 
-		if _, err := tx.CreateBucketIfNotExists(nil, false); err != bolt.ErrBucketNameRequired {
+		if _, err := tx.CreateBucketIfNotExists(nil); err != bolt.ErrBucketNameRequired {
 			t.Fatalf("unexpected error: %s", err)
 		}
 
@@ -316,7 +316,7 @@ func TestTx_CreateBucket_ErrBucketExists(t *testing.T) {
 
 	// Create a bucket.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -326,7 +326,7 @@ func TestTx_CreateBucket_ErrBucketExists(t *testing.T) {
 
 	// Create the same bucket again.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if _, err := tx.CreateBucket([]byte("widgets"), false); err != bolt.ErrBucketExists {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != bolt.ErrBucketExists {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		return nil
@@ -340,7 +340,7 @@ func TestTx_CreateBucket_ErrBucketNameRequired(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if _, err := tx.CreateBucket(nil, false); err != bolt.ErrBucketNameRequired {
+		if _, err := tx.CreateBucket(nil); err != bolt.ErrBucketNameRequired {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		return nil
@@ -356,7 +356,7 @@ func TestTx_DeleteBucket(t *testing.T) {
 
 	// Create a bucket and add a value.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -383,7 +383,7 @@ func TestTx_DeleteBucket(t *testing.T) {
 
 	if err := db.Update(func(tx *bolt.Tx) error {
 		// Create the bucket again and make sure there's not a phantom value.
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -446,7 +446,7 @@ func TestTx_ForEach_NoError(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -470,7 +470,7 @@ func TestTx_ForEach_WithError(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -499,7 +499,7 @@ func TestTx_OnCommit(t *testing.T) {
 	if err := db.Update(func(tx *bolt.Tx) error {
 		tx.OnCommit(func() { x += 1 })
 		tx.OnCommit(func() { x += 2 })
-		if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -519,7 +519,7 @@ func TestTx_OnCommit_Rollback(t *testing.T) {
 	if err := db.Update(func(tx *bolt.Tx) error {
 		tx.OnCommit(func() { x += 1 })
 		tx.OnCommit(func() { x += 2 })
-		if _, err := tx.CreateBucket([]byte("widgets"), false); err != nil {
+		if _, err := tx.CreateBucket([]byte("widgets")); err != nil {
 			t.Fatal(err)
 		}
 		return errors.New("rollback this commit")
@@ -537,7 +537,7 @@ func TestTx_CopyFile(t *testing.T) {
 
 	path := tempfile()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -606,7 +606,7 @@ func TestTx_CopyFile_Error_Meta(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -633,7 +633,7 @@ func TestTx_CopyFile_Error_Normal(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -665,7 +665,7 @@ func ExampleTx_Rollback() {
 
 	// Create a bucket.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucket([]byte("widgets"), false)
+		_, err := tx.CreateBucket([]byte("widgets"))
 		return err
 	}); err != nil {
 		log.Fatal(err)
@@ -719,7 +719,7 @@ func ExampleTx_CopyFile() {
 
 	// Create a bucket and a key.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucket([]byte("widgets"), false)
+		b, err := tx.CreateBucket([]byte("widgets"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Port of https://github.com/etcd-io/bbolt/commit/543c40ab4152935b36df4fba524e741046a359d4
- Now tests don't crush with -race flag 

- Also found new race, reported to etcd/bolt: https://github.com/etcd-io/bbolt/issues/213