### PR TITLE
[uncompatible db format] Fix unsafe pointer conversions caught by Go 1.14 checkptr

### DIFF
--- a/bolt_386.go
+++ b/bolt_386.go
@@ -5,6 +5,3 @@ const maxMapSize = 0x7FFFFFFF // 2GB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0xFFFFFFF
-
-// Are unaligned load/stores broken on this arch?
-var brokenUnaligned = false

--- a/bolt_amd64.go
+++ b/bolt_amd64.go
@@ -5,6 +5,3 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
-
-// Are unaligned load/stores broken on this arch?
-var brokenUnaligned = false

--- a/bolt_arm.go
+++ b/bolt_arm.go
@@ -1,28 +1,7 @@
 package bolt
 
-import "unsafe"
-
 // maxMapSize represents the largest mmap size supported by Bolt.
 const maxMapSize = 0x7FFFFFFF // 2GB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0xFFFFFFF
-
-// Are unaligned load/stores broken on this arch?
-var brokenUnaligned bool
-
-func init() {
-	// Simple check to see whether this arch handles unaligned load/stores
-	// correctly.
-
-	// ARM9 and older devices require load/stores to be from/to aligned
-	// addresses. If not, the lower 2 bits are cleared and that address is
-	// read in a jumbled up order.
-
-	// See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka15414.html
-
-	raw := [6]byte{0xfe, 0xef, 0x11, 0x22, 0x22, 0x11}
-	val := *(*uint32)(unsafe.Pointer(uintptr(unsafe.Pointer(&raw)) + 2))
-
-	brokenUnaligned = val != 0x11222211
-}

--- a/bolt_arm64.go
+++ b/bolt_arm64.go
@@ -7,6 +7,3 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
-
-// Are unaligned load/stores broken on this arch?
-var brokenUnaligned = false

--- a/bolt_ppc64.go
+++ b/bolt_ppc64.go
@@ -7,6 +7,3 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
-
-// Are unaligned load/stores broken on this arch?
-var brokenUnaligned = false

--- a/bolt_ppc64le.go
+++ b/bolt_ppc64le.go
@@ -7,6 +7,3 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
-
-// Are unaligned load/stores broken on this arch?
-var brokenUnaligned = false

--- a/bolt_s390x.go
+++ b/bolt_s390x.go
@@ -7,6 +7,3 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
-
-// Are unaligned load/stores broken on this arch?
-var brokenUnaligned = false

--- a/bucket.go
+++ b/bucket.go
@@ -554,7 +554,7 @@ func (b *Bucket) Stats() BucketStats {
 
 			if p.count != 0 {
 				// If page has any elements, add all element headers.
-				used += leafPageElementSize * int(p.count-1)
+				used += leafPageElementSize * uintptr(p.count-1)
 
 				// Add all element key, value sizes.
 				// The computation takes advantage of the fact that the position
@@ -562,16 +562,16 @@ func (b *Bucket) Stats() BucketStats {
 				// of all previous elements' keys and values.
 				// It also includes the last element's header.
 				lastElement := p.leafPageElement(p.count - 1)
-				used += int(lastElement.pos + lastElement.ksize + lastElement.vsize)
+				used += uintptr(lastElement.pos + lastElement.ksize + lastElement.vsize)
 			}
 
 			if b.root == 0 {
 				// For inlined bucket just update the inline stats
-				s.InlineBucketInuse += used
+				s.InlineBucketInuse += int(used)
 			} else {
 				// For non-inlined bucket update all the leaf stats
 				s.LeafPageN++
-				s.LeafInuse += used
+				s.LeafInuse += int(used)
 				s.LeafOverflowN += int(p.overflow)
 
 				// Collect stats from sub-buckets.
@@ -588,31 +588,31 @@ func (b *Bucket) Stats() BucketStats {
 			}
 		} else if (p.flags & branchPageFlag) != 0 {
 			s.BranchPageN++
-			var used int
+			var used uintptr
 			if b.enum {
 				lastElement := p.branchPageElementX(p.count - 1)
 
 				// used totals the used bytes for the page
 				// Add header and all element headers.
-				used = pageHeaderSize + (branchPageElementSizeX * int(p.count-1))
+				used = pageHeaderSize + (branchPageElementSizeX * uintptr(p.count-1))
 
 				// Add size of all keys and values.
 				// Again, use the fact that last element's position equals to
 				// the total of key, value sizes of all previous elements.
-				used += int(lastElement.pos + lastElement.ksize)
+				used += uintptr(lastElement.pos + lastElement.ksize)
 			} else {
 				lastElement := p.branchPageElement(p.count - 1)
 
 				// used totals the used bytes for the page
 				// Add header and all element headers.
-				used = pageHeaderSize + (branchPageElementSize * int(p.count-1))
+				used = pageHeaderSize + (branchPageElementSize * uintptr(p.count-1))
 
 				// Add size of all keys and values.
 				// Again, use the fact that last element's position equals to
 				// the total of key, value sizes of all previous elements.
-				used += int(lastElement.pos + lastElement.ksize)
+				used += uintptr(lastElement.pos + lastElement.ksize)
 			}
-			s.BranchInuse += used
+			s.BranchInuse += int(used)
 			s.BranchOverflowN += int(p.overflow)
 		}
 
@@ -758,7 +758,7 @@ func (b *Bucket) inlineable() bool {
 	var size = pageHeaderSize
 	var prefix []byte
 	for i, inode := range n.inodes {
-		size += leafPageElementSize + len(inode.key) + len(inode.value)
+		size += leafPageElementSize + uintptr(len(inode.key)) + uintptr(len(inode.value))
 		if !b.tx.db.KeysPrefixCompressionDisable {
 			if prefix == nil {
 				prefix = inode.key
@@ -775,7 +775,7 @@ func (b *Bucket) inlineable() bool {
 		}
 		if inode.flags&bucketLeafFlag != 0 {
 			return false
-		} else if size-len(prefix)*i > b.maxInlineBucketSize() {
+		} else if size-uintptr(len(prefix)*i) > b.maxInlineBucketSize() {
 			return false
 		}
 	}
@@ -784,8 +784,8 @@ func (b *Bucket) inlineable() bool {
 }
 
 // Returns the maximum total size of a bucket to make it a candidate for inlining.
-func (b *Bucket) maxInlineBucketSize() int {
-	return b.tx.db.pageSize / 4
+func (b *Bucket) maxInlineBucketSize() uintptr {
+	return uintptr(b.tx.db.pageSize / 4)
 }
 
 // write allocates and writes a bucket to a byte slice.

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -1213,19 +1213,19 @@ func _TestBucket_Stats(t *testing.T) {
 			t.Fatalf("unexpected Depth: %d", stats.Depth)
 		}
 
-		branchInuse := 16     // branch page header
-		branchInuse += 7 * 16 // branch elements
-		branchInuse += 7 * 3  // branch keys (6 3-byte keys)
+		branchInuse := pageHeaderSize // branch page header
+		branchInuse += 7 * 16         // branch elements
+		branchInuse += 7 * 3          // branch keys (6 3-byte keys)
 		if stats.BranchInuse != branchInuse {
-			t.Fatalf("unexpected BranchInuse: %d", stats.BranchInuse)
+			t.Fatalf("unexpected BranchInuse: %d %d", stats.BranchInuse, branchInuse)
 		}
 
-		leafInuse := 7 * 16                      // leaf page header
+		leafInuse := 7 * pageHeaderSize          // leaf page header
 		leafInuse += 501 * 16                    // leaf elements
 		leafInuse += 500*3 + len(bigKey)         // leaf keys
 		leafInuse += 1*10 + 2*90 + 3*400 + 10000 // leaf values
 		if stats.LeafInuse != leafInuse {
-			t.Fatalf("unexpected LeafInuse: %d", stats.LeafInuse)
+			t.Fatalf("unexpected LeafInuse: %d %d", stats.LeafInuse, leafInuse)
 		}
 
 		// Only check allocations for 4KB pages.
@@ -1320,7 +1320,7 @@ func _TestBucket_Stats_RandomFill(t *testing.T) {
 }
 
 // Ensure a bucket can calculate stats.
-func _TestBucket_Stats_Small(t *testing.T) {
+func TestBucket_Stats_Small(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 
@@ -1374,7 +1374,7 @@ func _TestBucket_Stats_Small(t *testing.T) {
 			t.Fatalf("unexpected BucketN: %d", stats.BucketN)
 		} else if stats.InlineBucketN != 1 {
 			t.Fatalf("unexpected InlineBucketN: %d", stats.InlineBucketN)
-		} else if stats.InlineBucketInuse != 16+16+6 {
+		} else if stats.InlineBucketInuse != 32+16+6 {
 			t.Fatalf("unexpected InlineBucketInuse: %d", stats.InlineBucketInuse)
 		}
 
@@ -1384,7 +1384,7 @@ func _TestBucket_Stats_Small(t *testing.T) {
 	}
 }
 
-func _TestBucket_Stats_EmptyBucket(t *testing.T) {
+func TestBucket_Stats_EmptyBucket(t *testing.T) {
 	db := MustOpenDB()
 	defer db.MustClose()
 
@@ -1433,7 +1433,7 @@ func _TestBucket_Stats_EmptyBucket(t *testing.T) {
 			t.Fatalf("unexpected BucketN: %d", stats.BucketN)
 		} else if stats.InlineBucketN != 1 {
 			t.Fatalf("unexpected InlineBucketN: %d", stats.InlineBucketN)
-		} else if stats.InlineBucketInuse != 16 {
+		} else if stats.InlineBucketInuse != 32 {
 			t.Fatalf("unexpected InlineBucketInuse: %d", stats.InlineBucketInuse)
 		}
 
@@ -1536,7 +1536,7 @@ func _TestBucket_Stats_Nested(t *testing.T) {
 		} else if stats.InlineBucketN != 1 {
 			t.Fatalf("unexpected InlineBucketN: %d", stats.InlineBucketN)
 		} else if stats.InlineBucketInuse != baz {
-			t.Fatalf("unexpected InlineBucketInuse: %d", stats.InlineBucketInuse)
+			t.Fatalf("unexpected InlineBucketInuse: %d %d", stats.InlineBucketInuse, baz)
 		}
 
 		return nil

--- a/db.go
+++ b/db.go
@@ -1004,8 +1004,9 @@ type Options struct {
 // DefaultOptions represent the options used if nil options are passed into Open().
 // No timeout is used which will cause Bolt to wait indefinitely for a lock.
 var DefaultOptions = &Options{
-	Timeout:    0,
-	NoGrowSync: false,
+	Timeout:                      0,
+	NoGrowSync:                   false,
+	KeysPrefixCompressionDisable: false,
 }
 
 // Stats represents statistics about the database.

--- a/db_test.go
+++ b/db_test.go
@@ -24,17 +24,11 @@ import (
 
 var statsFlag = flag.Bool("stats", false, "show performance stats")
 
-// version is the data file format version.
-const version = 2
-
-// magic is the marker value to indicate that a file is a Bolt DB.
-const magic uint32 = 0xED0CDAED
-
 // pageSize is the size of one page in the data file.
 const pageSize = 4096
 
 // pageHeaderSize is the size of a page header.
-const pageHeaderSize = 16
+const pageHeaderSize = 32
 
 // meta represents a simplified version of a database meta page for testing.
 type meta struct {
@@ -147,7 +141,7 @@ func TestOpen_ErrInvalid(t *testing.T) {
 }
 
 // Ensure that opening a file with two invalid versions returns ErrVersionMismatch.
-func _TestOpen_ErrVersionMismatch(t *testing.T) {
+func TestOpen_ErrVersionMismatch(t *testing.T) {
 	if pageSize != os.Getpagesize() {
 		t.Skip("page size mismatch")
 	}

--- a/freelist.go
+++ b/freelist.go
@@ -2,6 +2,7 @@ package bolt
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"unsafe"
 )
@@ -29,7 +30,7 @@ func (f *freelist) size() int {
 		// The first element will be used to store the count. See freelist.write.
 		n++
 	}
-	return pageHeaderSize + (int(unsafe.Sizeof(pgid(0))) * n)
+	return int(pageHeaderSize) + (int(unsafe.Sizeof(pgid(0))) * n)
 }
 
 // count returns count of pages on the freelist
@@ -49,6 +50,23 @@ func (f *freelist) pending_count() int {
 		count += len(list)
 	}
 	return count
+}
+
+// copyallunsafe copies a list of all free ids and all pending ids in one sorted list.
+// f.count returns the minimum length required for dst.
+func (f *freelist) copyallunsafe(dstptr unsafe.Pointer) { // dstptr is []pgid data pointer
+	m := make(pgids, 0, f.pending_count())
+	for _, list := range f.pending {
+		m = append(m, list...)
+	}
+	sort.Sort(m)
+	sz := len(f.ids) + len(m)
+	dst := *(*[]pgid)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: uintptr(dstptr),
+		Len:  sz,
+		Cap:  sz,
+	}))
+	mergepgids(dst, f.ids, m)
 }
 
 // copyall copies into dst a list of all free ids and all pending ids in one sorted list.
@@ -163,17 +181,21 @@ func (f *freelist) freed(pgid pgid) bool {
 func (f *freelist) read(p *page) {
 	// If the page.count is at the max uint16 value (64k) then it's considered
 	// an overflow and the size of the freelist is stored as the first element.
-	idx, count := 0, int(p.count)
+	var idx, count uintptr = 0, uintptr(p.count)
 	if count == 0xFFFF {
 		idx = 1
-		count = int(((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[0])
+		count = uintptr(*(*pgid)(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + pageHeaderSize)))
 	}
 
 	// Copy the list of page ids from the freelist.
 	if count == 0 {
 		f.ids = nil
 	} else {
-		ids := ((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[idx:count]
+		ids := *(*[]pgid)(unsafe.Pointer(&reflect.SliceHeader{
+			Data: uintptr(unsafe.Pointer(p)) + pageHeaderSize + idx*unsafe.Sizeof(pgid(0)),
+			Len:  int(count),
+			Cap:  int(count),
+		}))
 		f.ids = make([]pgid, len(ids))
 		copy(f.ids, ids)
 
@@ -201,11 +223,11 @@ func (f *freelist) write(p *page) error {
 		p.count = uint16(lenids)
 	} else if lenids < 0xFFFF {
 		p.count = uint16(lenids)
-		f.copyall(((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[:])
+		f.copyallunsafe(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + pageHeaderSize))
 	} else {
 		p.count = 0xFFFF
-		((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[0] = pgid(lenids)
-		f.copyall(((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[1:])
+		*(*pgid)(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + pageHeaderSize)) = pgid(lenids)
+		f.copyallunsafe(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + pageHeaderSize + unsafe.Sizeof(pgid(0))))
 	}
 
 	return nil

--- a/freelist_test.go
+++ b/freelist_test.go
@@ -95,7 +95,7 @@ func TestFreelist_read(t *testing.T) {
 	page.count = 2
 
 	// Insert 2 page ids.
-	ids := (*[3]pgid)(unsafe.Pointer(&page.ptr))
+	ids := (*[3]pgid)(unsafe.Pointer(uintptr(unsafe.Pointer(page)) + pageHeaderSize))
 	ids[0] = 23
 	ids[1] = 50
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200331124033-c3d80250170d h1:nc5K6ox/4lTFbMVSL9WRR81ixkcwXThoiF6yf+R9scA=
-golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/node.go
+++ b/node.go
@@ -305,6 +305,7 @@ func (n *node) write(p *page) {
 		_assert(plen == 0, "key prefix: non-zero prefix in db with disabled keys compression")
 	}
 
+	p.minsize = minSize
 	bp := uintptr(unsafe.Pointer(p)) + pageHeaderSize + n.pageElementSize()*uintptr(len(n.inodes))
 	b := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
 		Data: bp,

--- a/node_test.go
+++ b/node_test.go
@@ -39,7 +39,7 @@ func TestNode_read_LeafPage(t *testing.T) {
 	page.count = 2
 
 	// Insert 2 elements at the beginning. sizeof(leafPageElement) == 16
-	nodes := (*[3]leafPageElement)(unsafe.Pointer(&page.ptr))
+	nodes := (*[3]leafPageElement)(unsafe.Pointer(uintptr(unsafe.Pointer(page)) + pageHeaderSize))
 	nodes[0] = leafPageElement{flags: 0, pos: 32, ksize: 3, vsize: 4}  // pos = sizeof(leafPageElement) * 2
 	nodes[1] = leafPageElement{flags: 0, pos: 23, ksize: 10, vsize: 3} // pos = sizeof(leafPageElement) + 3 + 4
 

--- a/page.go
+++ b/page.go
@@ -56,8 +56,6 @@ func (p *page) typ() string {
 
 // meta returns a pointer to the metadata section of the page.
 func (p *page) meta() *meta {
-	fmt.Printf("a: %#v\n", (*meta)(unsafe.Pointer(uintptr(unsafe.Pointer(p))+pageHeaderSize)))
-	fmt.Printf("b: %#v\n", (*meta)(unsafe.Pointer(uintptr(unsafe.Pointer(p))+unsafe.Sizeof(*p))))
 	return (*meta)(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + pageHeaderSize))
 }
 

--- a/page.go
+++ b/page.go
@@ -56,6 +56,8 @@ func (p *page) typ() string {
 
 // meta returns a pointer to the metadata section of the page.
 func (p *page) meta() *meta {
+	fmt.Printf("a: %#v\n", (*meta)(unsafe.Pointer(uintptr(unsafe.Pointer(p))+pageHeaderSize)))
+	fmt.Printf("b: %#v\n", (*meta)(unsafe.Pointer(uintptr(unsafe.Pointer(p))+unsafe.Sizeof(*p))))
 	return (*meta)(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + pageHeaderSize))
 }
 

--- a/tx.go
+++ b/tx.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -477,7 +478,7 @@ func (tx *Tx) allocate(count int) (*page, error) {
 	tx.pages[p.id] = p
 
 	// Update statistics.
-	tx.stats.PageCount++
+	tx.stats.PageCount += count
 	tx.stats.PageAlloc += count * tx.db.pageSize
 
 	return p, nil
@@ -500,7 +501,7 @@ func (tx *Tx) write() error {
 		offset := int64(p.id) * int64(tx.db.pageSize)
 
 		// Write out page in "max allocation" sized chunks.
-		ptr := (*[maxAllocSize]byte)(unsafe.Pointer(p))
+		ptr := uintptr(unsafe.Pointer(p))
 		for {
 			// Limit our write to our max allocation size.
 			sz := size
@@ -509,13 +510,17 @@ func (tx *Tx) write() error {
 			}
 
 			// Write chunk to disk.
-			buf := ptr[:sz]
+			buf := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+				Data: ptr,
+				Len:  sz,
+				Cap:  sz,
+			}))
 			if _, err := tx.db.ops.writeAt(buf, offset); err != nil {
 				return err
 			}
 
 			// Update statistics.
-			tx.stats.Write += sz
+			tx.stats.Write++
 
 			// Exit inner for loop if we've written all the chunks.
 			size -= sz
@@ -525,7 +530,7 @@ func (tx *Tx) write() error {
 
 			// Otherwise move offset forward and move pointer to next chunk.
 			offset += int64(sz)
-			ptr = (*[maxAllocSize]byte)(unsafe.Pointer(&ptr[sz]))
+			ptr += uintptr(sz)
 		}
 	}
 
@@ -544,7 +549,11 @@ func (tx *Tx) write() error {
 			continue
 		}
 
-		buf := (*[maxAllocSize]byte)(unsafe.Pointer(p))[:tx.db.pageSize]
+		buf := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+			Data: uintptr(unsafe.Pointer(p)),
+			Len:  tx.db.pageSize,
+			Cap:  tx.db.pageSize,
+		}))
 
 		// See https://go.googlesource.com/go/+/f03c9202c43e0abb130669852082117ca50aa9b1
 		for i := range buf {


### PR DESCRIPTION
Port of etcd-io@543c40a

Go 1.4 is more strict with -race flag - it checking incorrect work with unsafe package and crush if find something he doesn't like (for example if something is not cross-platform enough). 

- Now tests don't crush with -race flag 
- Can remove 1 uintptr field from page struct: https://github.com/ledgerwatch/bolt/pull/22/files#diff-dbab938ba1e6c4d3ab62c256a8d852b7L38 (but it will change DB format, can keep it but don't use also)

Others: 
- Also found new race, reported to etcd/bolt: etcd-io#213