### PR TITLE
MultiPut: remove copying of key/value

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -310,7 +310,7 @@ func (b *Bucket) Put(key []byte, value []byte) error {
 	}
 
 	// Insert into node.
-	key = cloneBytes(key)
+	//key = cloneBytes(key)
 	if c.node().put(key, key, value, 0, 0, 0) {
 		// Increment size on all references starting from the top
 		var n = c.stack[0].node

--- a/bucket.go
+++ b/bucket.go
@@ -367,11 +367,9 @@ func (b *Bucket) MultiPut(pairs ...[]byte) error {
 			return ErrIncompatibleValue
 		}
 		// Insert into node.
-		key = cloneBytes(key)
 		if value == nil {
 			c.node().del(key)
 		} else {
-			value = cloneBytes(value)
 			if c.node().put(key, key, value, 0, 0, 0) {
 				// Increment size on all references starting from the top
 				var n = c.stack[0].node

--- a/cmd/bolt/main_test.go
+++ b/cmd/bolt/main_test.go
@@ -408,7 +408,7 @@ func fillBucket(b *bolt.Bucket, prefix []byte) error {
 	}
 	n = 1 + rand.Intn(3)
 	for i := 0; i < n; i++ {
-		k := append(prefix, []byte(fmt.Sprintf("b%d", i))...)
+		k := append(append([]byte{}, prefix...), []byte(fmt.Sprintf("b%d", i))...)
 		sb, err := b.CreateBucket(k, false)
 		if err != nil {
 			return err


### PR DESCRIPTION
`.Put` also does copying of keys, there no much reasoning behind it. It was introduced in  https://github.com/boltdb/bolt/issues/143

Can remove copying from `.Put` as well. 